### PR TITLE
Age-range based Lorenzen M as case 6

### DIFF
--- a/9control.tex
+++ b/9control.tex
@@ -357,7 +357,7 @@ Auto-generation is a useful way to automatically create the required short time-
 Natural mortality (M) options include some options that are referenced to integer age and other options to real age since settlement.  If using an option that references M to real age since settlement, M varies by age and will change by season (e.g., cohorts born early in the year will have different M than cohorts born later in the year).
 
 \myparagraph{Lorenzen Natural Mortality}
-Lorenzen natural mortality is based on the concept that natural mortality is driven by physiological and ecological processes and varies over the life cycle of a fish. So, natural mortality is scaled by the length of the fish.
+Lorenzen natural mortality is based on the concept that natural mortality is driven by physiological and ecological processes and varies over the life cycle of a fish. So, natural mortality is scaled by the length of the fish. In this implementation, a reference age and M value are read in, and other ages will have an M scaled to its body size-at-age.  However, if platoons are used, all will have the same M as their growth pattern.  Lorenzen M calculation will be updated if the starting year growth parameters are active, but if growth parameters vary during the time-series, the M is not further updated.  Be careful in using Lorenzen when there is time-varying growth.
 
 \myparagraph{Age-specific M Linked to Age-Specific Length and Maturity}
 
@@ -391,6 +391,11 @@ Some suggested defaults for user-provided parameter inputs are:
  \item $M_{juv,s} = 3W_{mat}^{-0.288}$ from \citet{lorenzen1996relationship}
 \end{itemize}
 
+\myparagraph{Age-range Lorenzen}
+The original implementation of Lorenzen natural mortality in Stock Synthesis uses a reference age and its associated natural mortality as inputs to determine the Lorenzen curve. However, sometimes this information is not known. The age-range Lorenzen instead uses a range of ages and the average natural mortality over them to calculate a Lorenzen natural mortality curve.
+
+Like the original Lorenzen options, ages will have an M scaled to its body size-at-age and care should be taken when there are multiple growth patterns or time-varying growth.
+
 \myparagraph{Natural Mortality Options}
 \begin{longtable}{p{0.5cm} p{2cm} p{12.75cm}}
 	\hline	
@@ -415,7 +420,7 @@ Some suggested defaults for user-provided parameter inputs are:
 	  & & 3 = Read age specific M and do not do seasonal interpolation;\\
 	  & & 4 = Read age specific and do seasonal interpolation, if appropriate;\\
 	  & & 5 = age-specific M linked to age-specific length and maturity (experimental);\\
-	  & & 6 = Age range Lorenzen. \Bstrut\\
+	  & & 6 = Age-range Lorenzen. \Bstrut\\
 	\hline
 
 	\multicolumn{2}{l}{COND = 0} & No additional natural mortality controls. \Tstrut\Bstrut\\
@@ -428,7 +433,7 @@ Some suggested defaults for user-provided parameter inputs are:
 	\hline
 	
 	\multicolumn{2}{l}{COND = 2} & \Tstrut\\
-	& 4 \Tstrut & Reference age for Lorenzen natural mortality: read one additional integer value that is the reference age. Later read one parameter for each sex x growth pattern that will be the M at the reference age.  Other ages will have an M scaled to its body size-at-age.  However, if platoons are used, all will have the same M as their growth pattern.  Lorenzen M calculation will be updated if the starting year growth parameters are active, but if growth parameters vary during the time-series, the M is not further updated.  So be careful in using Lorenzen when there is time-varying growth.\\
+	& 4 \Tstrut & Reference age for Lorenzen natural mortality: read one additional integer value that is the reference age. Later read one long parameter line for each sex x growth pattern that will be the M at the reference age.  \\
 	\hline
 	
 	\multicolumn{2}{l}{COND = 3 or 4} \Tstrut & Do not read any natural mortality parameters in the mortality growth parameter section.  With option 3, these M values are held fixed for the integer age (no seasonality or birth season considerations). With option 4, there is seasonal interpolation based on real age, just as in options 1 and 2.\\
@@ -443,7 +448,7 @@ Some suggested defaults for user-provided parameter inputs are:
 	&  & 3 = Requires 6 long parameter lines per sex x growth pattern\Bstrut\\
 	\hline
 
-	\multicolumn{2}{l}{COND = 6} \Tstrut & Read two additional integer values that are the age range for average M. Later read one parameter for each sex x growth pattern that will be the average M over the reference age range.  Ages will have an M scaled to its body size-at-age.  However, if platoons are used, all will have the same M as their growth pattern.  Lorenzen M calculation will be updated if the starting year growth parameters are active, but if growth parameters vary during the time-series, the M is not further updated.  So be careful in using Lorenzen when there is time-varying growth.\\
+	\multicolumn{2}{l}{COND = 6} \Tstrut & Read two additional integer values that are the age range for average M. Later, read one long parameter line for each sex x growth pattern that will be the average M over the reference age range. \\
 	& 0 \Tstrut & Minimum age of average M range for calculating Lorenzen natural mortality.\\
 	& 10 \Tstrut & Maximum age of average M range for calculating Lorenzen natural mortality.\\ 
 	\hline

--- a/9control.tex
+++ b/9control.tex
@@ -415,7 +415,7 @@ Some suggested defaults for user-provided parameter inputs are:
 	  & & 3 = Read age specific M and do not do seasonal interpolation;\\
 	  & & 4 = Read age specific and do seasonal interpolation, if appropriate;\\
 	  & & 5 = age-specific M linked to age-specific length and maturity (experimental);\\
-	  & & 6 = Survivorship based Lorenzen. \Bstrut\\
+	  & & 6 = Age range Lorenzen. \Bstrut\\
 	\hline
 
 	\multicolumn{2}{l}{COND = 0} & No additional natural mortality controls. \Tstrut\Bstrut\\
@@ -443,9 +443,9 @@ Some suggested defaults for user-provided parameter inputs are:
 	&  & 3 = Requires 6 long parameter lines per sex x growth pattern\Bstrut\\
 	\hline
 
-	\multicolumn{2}{l}{COND = 6} \Tstrut & Read two additional integer values that are the reference range that survivorship is calculated over. Later read one parameter for each sex x growth pattern that will be the survivorship over the reference age range.  Ages will have an M scaled to its body size-at-age.  However, if platoons are used, all will have the same M as their growth pattern.  Lorenzen M calculation will be updated if the starting year growth parameters are active, but if growth parameters vary during the time-series, the M is not further updated.  So be careful in using Lorenzen when there is time-varying growth.\\
-	& 0 \Tstrut & Minimum age of survivorship range for calculating Lorenzen natural mortality.\\
-	& 10 \Tstrut & Maximum age of survivorship range for calculating Lorenzen natural mortality.\\ 
+	\multicolumn{2}{l}{COND = 6} \Tstrut & Read two additional integer values that are the age range for average M. Later read one parameter for each sex x growth pattern that will be the average M over the reference age range.  Ages will have an M scaled to its body size-at-age.  However, if platoons are used, all will have the same M as their growth pattern.  Lorenzen M calculation will be updated if the starting year growth parameters are active, but if growth parameters vary during the time-series, the M is not further updated.  So be careful in using Lorenzen when there is time-varying growth.\\
+	& 0 \Tstrut & Minimum age of average M range for calculating Lorenzen natural mortality.\\
+	& 10 \Tstrut & Maximum age of average M range for calculating Lorenzen natural mortality.\\ 
 	\hline
 \end{longtable}
 

--- a/9control.tex
+++ b/9control.tex
@@ -413,8 +413,9 @@ Some suggested defaults for user-provided parameter inputs are:
 	  & & 1 = N breakpoints;\\
 	  & & 2 = Lorenzen; \\
 	  & & 3 = Read age specific M and do not do seasonal interpolation;\\
-	  & & 4 = Read age specific and do seasonal interpolation, if appropriate; and\\
-	  & & 5 = age-specific M linked to age-specific length and maturity (experimental). \Bstrut\\
+	  & & 4 = Read age specific and do seasonal interpolation, if appropriate;\\
+	  & & 5 = age-specific M linked to age-specific length and maturity (experimental);\\
+	  & & 6 = Survivorship based Lorenzen. \Bstrut\\
 	\hline
 
 	\multicolumn{2}{l}{COND = 0} & No additional natural mortality controls. \Tstrut\Bstrut\\
@@ -440,6 +441,11 @@ Some suggested defaults for user-provided parameter inputs are:
 	&  & 1 = Requires 4 long parameter lines per sex x growth pattern using maturity. Must be used with maturity option 1; \\
 	&  & 2 = reserved for future option; \\
 	&  & 3 = Requires 6 long parameter lines per sex x growth pattern\Bstrut\\
+	\hline
+
+	\multicolumn{2}{l}{COND = 6} \Tstrut & Read two additional integer values that are the reference range that survivorship is calculated over. Later read one parameter for each sex x growth pattern that will be the survivorship over the reference age range.  Ages will have an M scaled to its body size-at-age.  However, if platoons are used, all will have the same M as their growth pattern.  Lorenzen M calculation will be updated if the starting year growth parameters are active, but if growth parameters vary during the time-series, the M is not further updated.  So be careful in using Lorenzen when there is time-varying growth.\\
+	& 0 \Tstrut & Minimum age of survivorship range for calculating Lorenzen natural mortality.\\
+	& 10 \Tstrut & Maximum age of survivorship range for calculating Lorenzen natural mortality.\\ 
 	\hline
 \end{longtable}
 


### PR DESCRIPTION
This addresses issue #114 survivorship-based Lorenzen M is now called via M case 6. Documentation is updated accordingly. This can be merged once SS issue #329 is accepted.