### PR TITLE
Size frequency modifications to the manual detailing Dirichlet and MV Tweedie data fitting

### DIFF
--- a/8data.tex
+++ b/8data.tex
@@ -972,7 +972,7 @@ The final two lines in the example above indicate in that variable series 1 will
 	\end{itemize}
 
 \subsection{Generalized Size Composition Data}
-The generalized approach to size composition information was designed initially to provide a means to include weight frequency data. However, the uses are broader, such as allowing for size composition data with different data bins. The user can define as many generlized size composition methods as necessary.
+The generalized approach to size composition information was designed initially to provide a means to include weight frequency data. However, the uses are broader, such as allowing for size composition data with different data bins. The user can define as many generalized size composition methods as necessary.
 
 \begin{itemize}
 	\item Each method has a specified number of bins.
@@ -991,14 +991,19 @@ The generalized approach to size composition information was designed initially 
 	\begin{tabular}{p{1.4cm} p{0.5cm} p{13 cm}}
 		\multicolumn{3}{l}{Example entry:}\\
 		\hline
-		2 &  & N of size frequency methods, if this value is 0, then omit all entries below. \Tstrut\Bstrut\\
+		2 &  & Number (N) of size frequency methods to be read. If this value is 0, then omit all entries below. If this value is -1 (or any negative value), expanded options inputs are required below. \Tstrut\Bstrut\\
 		\hline
+		\multicolumn{3}{l}{N of size frequency COND < 0 }  \Tstrut\\
+		multicolumn{2}{l}{2} & Number of size frequency methods to read\\
 		\multicolumn{3}{l}{COND > 0 }  \Tstrut\\
-		\multicolumn{2}{r}{25 15} & Nbins per method\\
+		\multicolumn{2}{r}{25 15} & Number of bins per method\\
 		\multicolumn{2}{r}{2 2} & Units per each method (1 = biomass, 2 = numbers)\\
 		\multicolumn{2}{r}{3 3} & Scale per each method (1 = kg, 2 = lbs, 3 = cm, 4 = inches)\\
 		\multicolumn{2}{r}{1e-9 1e-9} & Min compression to add to each observation (entry for each method)\\
-		\multicolumn{2}{r}{2 2} & N observations per weight frequency method \Bstrut\\
+		\multicolumn{2}{r}{2 2} & Number of observations per weight frequency method \Tstrut\\
+		\multicolumn{3}{l}{N of size frequency COND < 0 }  \Tstrut\\
+		\multicolumn{2}{r}{1 1} & Composition error structure (0 = multinomial, 1 = Dirichlet using Theta*n, 2 = Dirichlet using beta, 3 = MV Tweedie)\Tstrut\\
+		\multicolumn{2}{r}{1 1} & Consecutive index for Dirichlet or MV Tweedie composition error\Bstrut\\
 		\hline
 	\end{tabular}
 \end{center}

--- a/8data.tex
+++ b/8data.tex
@@ -988,22 +988,25 @@ The generalized approach to size composition information was designed initially 
 \end{itemize}
 
 \begin{center}
-	\begin{tabular}{p{1.4cm} p{0.5cm} p{13 cm}}
+	\begin{tabular}{p{1.4cm} p{0.7cm} p{12.8 cm}}
 		\multicolumn{3}{l}{Example entry:}\\
 		\hline
 		2 &  & Number (N) of size frequency methods to be read. If this value is 0, then omit all entries below. A value of -1 (or any negative value) triggers expanded optional inputs below that allow for either Dirichlet of two parameter Multivariate (MV) Tweedie likelihood for fitting these data. \Tstrut\Bstrut\\
 		\hline
-		\multicolumn{3}{l}{N of size frequency COND < 0 }  \Tstrut\\
+		\multicolumn{3}{l}{COND < 0 - Number of size frequency }  \Tstrut\\
 		\multicolumn{2}{l}{2} & Number of size frequency methods to read \Tstrut\\
-		\multicolumn{3}{l}{COND > 0 }  \Tstrut\\
-		\multicolumn{2}{r}{25 15} & Number of bins per method\\
+		\multicolumn{3}{l}{END COND < 0}  \Bstrut\\
+		\hline
+		\multicolumn{2}{r}{25 15} & Number of bins per method\Tstrut\\
 		\multicolumn{2}{r}{2 2} & Units per each method (1 = biomass, 2 = numbers)\\
 		\multicolumn{2}{r}{3 3} & Scale per each method (1 = kg, 2 = lbs, 3 = cm, 4 = inches)\\
 		\multicolumn{2}{r}{1e-9 1e-9} & Min compression to add to each observation (entry for each method)\\
-		\multicolumn{2}{r}{2 2} & Number of observations per weight frequency method \Tstrut\\
-		\multicolumn{3}{l}{N of size frequency COND < 0 }  \Tstrut\\
+		\multicolumn{2}{r}{2 2} & Number of observations per weight frequency method \Bstrut\\
+		\hline
+		\multicolumn{3}{l}{COND < 0 - Number of size frequency }  \Tstrut\\
 		\multicolumn{2}{r}{1 1} & Composition error structure (0 = multinomial, 1 = Dirichlet using Theta*n, 2 = Dirichlet using beta, 3 = MV Tweedie)\Tstrut\\
 		\multicolumn{2}{r}{1 1} & Parameter select consecutive index for Dirichlet or MV Tweedie composition error\Bstrut\\
+		\multicolumn{3}{l}{END COND < 0}  \Tstrut\\
 		\hline
 	\end{tabular}
 \end{center}

--- a/8data.tex
+++ b/8data.tex
@@ -991,10 +991,10 @@ The generalized approach to size composition information was designed initially 
 	\begin{tabular}{p{1.4cm} p{0.5cm} p{13 cm}}
 		\multicolumn{3}{l}{Example entry:}\\
 		\hline
-		2 &  & Number (N) of size frequency methods to be read. If this value is 0, then omit all entries below. If this value is -1 (or any negative value), expanded options inputs are required below. \Tstrut\Bstrut\\
+		2 &  & Number (N) of size frequency methods to be read. If this value is 0, then omit all entries below. A value of -1 (or any negative value) triggers expanded optional inputs below that allow for either Dirichlet of two parameter Multivariate (MV) Tweedie likelihood for fitting these data. \Tstrut\Bstrut\\
 		\hline
 		\multicolumn{3}{l}{N of size frequency COND < 0 }  \Tstrut\\
-		multicolumn{2}{l}{2} & Number of size frequency methods to read\\
+		\multicolumn{2}{l}{2} & Number of size frequency methods to read \Tstrut\\
 		\multicolumn{3}{l}{COND > 0 }  \Tstrut\\
 		\multicolumn{2}{r}{25 15} & Number of bins per method\\
 		\multicolumn{2}{r}{2 2} & Units per each method (1 = biomass, 2 = numbers)\\
@@ -1003,7 +1003,7 @@ The generalized approach to size composition information was designed initially 
 		\multicolumn{2}{r}{2 2} & Number of observations per weight frequency method \Tstrut\\
 		\multicolumn{3}{l}{N of size frequency COND < 0 }  \Tstrut\\
 		\multicolumn{2}{r}{1 1} & Composition error structure (0 = multinomial, 1 = Dirichlet using Theta*n, 2 = Dirichlet using beta, 3 = MV Tweedie)\Tstrut\\
-		\multicolumn{2}{r}{1 1} & Consecutive index for Dirichlet or MV Tweedie composition error\Bstrut\\
+		\multicolumn{2}{r}{1 1} & Parameter select consecutive index for Dirichlet or MV Tweedie composition error\Bstrut\\
 		\hline
 	\end{tabular}
 \end{center}


### PR DESCRIPTION
I followed the example data file and the information in data file reading in the [MV-Tweedie branch SS_write_ssnew file](https://github.com/nmfs-stock-synthesis/stock-synthesis/blob/MV-Tweedie-ver2/SS_write_ssnew.tpl). The changes to the manual are rather minor but I am not sure if there are additional edits to describe this new option within SS3.