### PR TITLE
Length bins

### DIFF
--- a/8data.tex
+++ b/8data.tex
@@ -708,12 +708,13 @@ Specify the length composition data as:
 		28 & Number of length bins for data  \\
 		\hline
 		26 28 30 ... 80 &  Vector of length bins associated with the length data\\
+		\hline
 	\end{tabular}
 \end{center}
 Note: the vector of length bins above will aggregate data from outside
 the range of values as follows:
 \begin{center}
-    \begin{tabular}{|l|c|c|c|c|c|c|c|c|c|}
+    \begin{tabular}{lccccccccc}
 		\hline
   		             & bin 1 & bin 2 & bin 3 & ... & bin 27 & bin 28 \\ 
 		\hline

--- a/8data.tex
+++ b/8data.tex
@@ -714,10 +714,12 @@ Note: the vector of length bins above will aggregate data from outside
 the range of values as follows:
 \begin{center}
     \begin{tabular}{|l|c|c|c|c|c|c|c|c|c|}
-		\setlength{\tabcolsep}{12pt}
-        bin number & 1 & 2 & 3 & ... & 27 & 28 \\ 
-        bin vector & 26 & 28 & 30 & ... & 78 & 80 \\ 
-        bin contains & 0--27.99 & 28--29.99 & 30--30.99 & ... & 78--79.99 & 80+ \\
+		\hline
+  		             & bin 1 & bin 2 & bin 3 & ... & bin 27 & bin 28 \\ 
+		\hline
+ 		bin vector   & 26 & 28 & 30 & ... & 78 & 80 \\ 
+    	bin contains & 0--27.99 & 28--29.99 & 30--30.99 & ... & 78--79.99 & 80+ \\
+		\hline
     \end{tabular}
 \end{center}
 
@@ -730,7 +732,8 @@ Example of a single length composition observation:
 		\hline
 		1986 & 1 & 1 & 3 & 0 & 20 & <female then male data> \Tstrut\\
 		... & ...& ... & ... & ...& ... & ... \\
--9999 & 0 & 0 & 0 & 0 & 0 & <0 repeated for each observation bin above> \Bstrut\\
+-9999 & 0 & 0 & 0 & 0 & 0 & <0 repeated for each element of the data
+vector above> \Bstrut\\
 		\hline	
 	\end{tabular}
 \end{center}

--- a/8data.tex
+++ b/8data.tex
@@ -703,21 +703,33 @@ The data bins do not need to cover all observed lengths.  The selection of data 
 
 Specify the length composition data as:
 \begin{center}
+	\begin{tabular}{p{4cm} p{10cm}}
+		\hline
+		28 & Number of length bins for data  \\
+		\hline
+		26 28 30 ... 80 &  Vector of length bins associated with the length data\\
+	\end{tabular}
+\end{center}
+Note: the vector of length bins above will aggregate data from outside
+the range of values as follows:
+\begin{center}
+    \begin{tabular}{|c|c|c|c|c|c|c|c|c|c|}
+        bin number & 1 & 2 & 3 & ... & 27 & 28 \\ 
+        bin vector & 26 & 28 & 30 & ... & 78 & 80 \\ 
+        bin contains & 0--27.99 & 28--29.99 & 30--30.99 & ... & 78--79.99 & 80+ \\
+    \end{tabular}
+\end{center}
+
+Example of a single length composition observation:
+\begin{center}
 	\begin{tabular}{p{1.5cm} p{1.5cm} p{1.5cm} p{1.5cm} p{1.5cm} p{1.5cm} p{5cm}}
-		\hline
-		\multicolumn{2}{l}{28} & \multicolumn{5}{l}{Number of length bins for data}\Tstrut\Bstrut\\
-		\hline
-		\multicolumn{2}{l}{26 28 30 ... 80} &  \multicolumn{5}{l}{Vector of length bins associated with the length data. }\Tstrut\Bstrut\\
-		\hline
-		\multicolumn{7}{l}{The above data bins will combine 0-26 cm fish, >26 - 28 cm, ..., and 80+ cm fish.} \\
-		\\
-		\multicolumn{7}{l}{Example of a single length composition observation:} \\
+		\multicolumn{7}{l}{} \\
 		\hline
 		Year & Month & Fleet & Sex & Partition & Nsamp & data vector\Tstrut\Bstrut\\
 		\hline
 		1986 & 1 & 1 & 3 & 0 & 20 & <female then male data> \Tstrut\\
 		... & ...& ... & ... & ...& ... & ... \\
-		-9999 & 0 & 0 & 0 & 0 & 0 & 0 \Bstrut\\
+-9999 & 0 & 0 & 0 & 0 & 0 & <0 repeated for each observation bin above> \Bstrut\\
 		\hline	
 	\end{tabular}
 \end{center}

--- a/8data.tex
+++ b/8data.tex
@@ -713,7 +713,8 @@ Specify the length composition data as:
 Note: the vector of length bins above will aggregate data from outside
 the range of values as follows:
 \begin{center}
-    \begin{tabular}{|c|c|c|c|c|c|c|c|c|c|}
+    \begin{tabular}{|l|c|c|c|c|c|c|c|c|c|}
+		\setlength{\tabcolsep}{12pt}
         bin number & 1 & 2 & 3 & ... & 27 & 28 \\ 
         bin vector & 26 & 28 & 30 & ... & 78 & 80 \\ 
         bin contains & 0--27.99 & 28--29.99 & 30--30.99 & ... & 78--79.99 & 80+ \\
@@ -910,7 +911,7 @@ composition data.
 	\hline
 \end{tabular}
 
-In this example observation, the age data is treated as on being conditional on the 2 cm length bins of 10-11.99, 12-13.99, 14-15.99, and 16-17.99cm. If there are no observations of ages for a specific sex within a length bin for a specific year, that entry may be omitted.
+In this example observation, the age data is treated as on being conditional on the 2 cm length bins of 10--11.99, 12--13.99, 14--15.99, and 16--17.99cm. If there are no observations of ages for a specific sex within a length bin for a specific year, that entry may be omitted.
 
 \subsection{Mean Length or Body Weight-at-Age}
 The model also accepts input of mean length-at-age or mean body weight-at-age.  This is done in terms of observed age, not true age, to take into account the effects of ageing imprecision on expected mean size-at-age.  If the value of the Age Error column is positive, then the observation is interpreted as mean length-at-age.  If the value of the Age Error column is negative, then the observation is interpreted as mean body weight-at-age and the abs(Age Error) is used as Age Error.


### PR DESCRIPTION
I got a question from somebody confused by the sentence "The above data bins will combine 0-26 cm fish, >26 - 28 cm, ..., and 80+ cm fish" which references the vector 26 28 30 ... 80. I think that's not right. The 26cm bin includes both 0-26 and 26-28 fish. This pull request includes my attempt to clean up that section.

It took me 4 tries to get the tables to work, so we should use the option to squash the commits when merging.

**HTML rendering:** (is there a way to turn off the bold in the first row?)
![image](https://user-images.githubusercontent.com/4992918/192651893-a1604d59-f2a2-4b89-8499-34f254335f9a.png)

**PDF rendering**:
![image](https://user-images.githubusercontent.com/4992918/192651803-73d6399d-b3a6-4999-929e-cbfb3cb807c0.png)
![image](https://user-images.githubusercontent.com/4992918/192652074-f07967fe-7a2f-4a34-be23-f78ecb08c67a.png)

