### PR TITLE
improve example input for "Controls for Variance of Derived Quantities"

### DIFF
--- a/9control.tex
+++ b/9control.tex
@@ -2598,11 +2598,17 @@ Depending upon the entered options above subsequent conditional inputs may be ne
 Example input:	
 \begin{quote}
 	\begin{verbatim}
-2 # (0/1/2) read specs for more stddev reporting: 0 = skip, 1 = read specs for reporting stdev for selectivity, size, and numbers, 2 = add options for M,Dyn. Bzero, SmryBio
- 1 1 -1 5 # Selectivity: (1) 0 to skip or fleet, (2) 1=len/2=age/3=combined, (3) year, (4) N selex bins; NOTE: combined reports in age bins
- 1 5 # Growth: (1) 0 to skip or growth pattern, (2) growth ages; NOTE: does each sex
- 1 -1 5 # Numbers-at-age: (1) 0 or area(-1 for all), (2) year, (3) N ages;  NOTE: sums across morphs
- 1 5 # Mortality: (1) 0 to skip or growth pattern, (2) N ages for mortality; NOTE: does each sex
+2 # (0/1/2) read specs for more stddev reporting: 
+  # 0 = skip, 1 = read specs for reporting stdev for selectivity, size, 
+  # and numbers, 2 = add options for M,Dyn. Bzero, SmryBio
+ 1 1 -1 5 # Selectivity: (1) 0 to skip or fleet, (2) 1=len/2=age/3=combined, 
+          # (3) year, (4) N selex bins; NOTE: combined reports in age bins
+ 1 5 # Growth: (1) 0 to skip or growth pattern, (2) growth ages; 
+     # NOTE: does each sex
+ 1 -1 5 # Numbers-at-age: (1) 0 or area(-1 for all), (2) year, (3) N ages;  
+        # NOTE: sums across morphs
+ 1 5 # Mortality: (1) 0 to skip or growth pattern, (2) N ages for mortality; 
+     # NOTE: does each sex
 1 # Dyn Bzero: 0 to skip, 1 to include, or 2 to add recr
 1 # SmryBio: 0 to skip, 1 to include
  5 15 25 35 38 # vector with selex std bins (-1 in first bin to self-generate)
@@ -2611,4 +2617,3 @@ Example input:
  1 2 5 10 15 # vector with NatM std ages picks (-1 in first bin to self-generate)
 \end{verbatim}
 \end{quote}
-

--- a/9control.tex
+++ b/9control.tex
@@ -2595,25 +2595,31 @@ Depending upon the entered options above subsequent conditional inputs may be ne
 		\end{itemize}
 \end{itemize}
 
-Example input:	
-\begin{quote}
-	\begin{verbatim}
-2 \# \(0/1/2\) read specs for more stddev reporting: 
-  \# 0 = skip, 1 = read specs for reporting stdev for selectivity, size, 
-  \# and numbers, 2 = add options for M,Dyn. Bzero, SmryBio
- 1 1 -1 5 \# Selectivity: \(1\) 0 to skip or fleet, \(2\) 1=len/2=age/3=combined, 
-          \# \(3\) year, \(4\) N selex bins; NOTE: combined reports in age bins
- 1 5 \# Growth: \(1\) 0 to skip or growth pattern, \(2\) growth ages; 
-     \# NOTE: does each sex
- 1 -1 5 \# Numbers-at-age: \(1\) 0 or area\(-1 for all\), \(2\) year, \(3\) N ages;  
-        \# NOTE: sums across morphs
- 1 5 \# Mortality: \(1\) 0 to skip or growth pattern, \(2\) N ages for mortality; 
-     \# NOTE: does each sex
-1 \# Dyn Bzero: 0 to skip, 1 to include, or 2 to add recr
-1 \# SmryBio: 0 to skip, 1 to include
- 5 15 25 35 38 \# vector with selex std bins \(-1 in first bin to self-generate\)
- 1 2 5 10 15 \# vector with growth std ages picks \(-1 in first bin to self-generate\)
- 1 2 5 10 15 \# vector with NatAge std ages \(-1 in first bin to self-generate\)
- 1 2 5 10 15 \# vector with NatM std ages picks \(-1 in first bin to self-generate\)
-\end{verbatim}
-\end{quote}
+\begin{longtable}{p{1.1cm} p{1.4cm} p{1.2cm} p{1.2cm} p{1.3cm} p{1.6cm} p{1.4cm} p{1.4cm} p{1.4cm}}
+	
+	\hline
+	\multicolumn{9}{l}{Example Input:}\Tstrut\Bstrut\\
+	\hline
+	
+	\multicolumn{3}{l}{2} & \multicolumn{6}{l}{\# 0 = No additional std dev reporting;} \Tstrut\\
+	\multicolumn{3}{l}{ } & \multicolumn{6}{l}{\# 1 = read values below; and}\Bstrut\\
+	\multicolumn{3}{l}{ } & \multicolumn{6}{l}{\# 2 = read specification for reporting stdev for selectivity, size,numbers, and }\Bstrut\\
+	\multicolumn{3}{l}{ } & \multicolumn{6}{l}{\# natural mortality.}\Bstrut\\
+	\hline
+	
+	\multicolumn{4}{l}{1 1 -1 5}  & \multicolumn{5}{l}{\# Selectivity} \Bstrut\\
+	\multicolumn{4}{l}{1 5}       & \multicolumn{5}{l}{\# Growth} \Bstrut\\
+	\multicolumn{4}{l}{1 -1 5}    & \multicolumn{5}{l}{\# Numbers-at-age} \Bstrut\\
+	\multicolumn{4}{l}{1 5}       & \multicolumn{5}{l}{\# M-at-age} \Bstrut\\
+	\multicolumn{4}{l}{1}         & \multicolumn{5}{l}{\# Dynamic Bzero} \Bstrut\\
+	\multicolumn{4}{l}{1}         & \multicolumn{5}{l}{\# Summary Biomass} \Bstrut\\
+	
+	\multicolumn{4}{l}{5 15 25 35 38} & \multicolumn{5}{l}{\# Vector with selectivity std bins (-1 in first bin to self-generate)}\Bstrut\\
+	\multicolumn{4}{l}{1 2 5 10 15}  & \multicolumn{5}{l}{\# Vector with growth std ages picks (-1 in first bin to self-generate)}\Bstrut\\
+	\multicolumn{4}{l}{1 2 5 10 15}  & \multicolumn{5}{l}{\# Vector with numbers-at-age std ages (-1 in first bin to self-generate)}\Bstrut\\
+	\multicolumn{4}{l}{1 2 5 10 15}  & \multicolumn{5}{l}{\# Vector with M-at-age std ages (-1 in first bin to self-generate)}\Bstrut\\
+	
+	\hline
+	\bfseries{999} & \multicolumn{8}{l}{\#End of the control file input}\Tstrut\Bstrut\\
+	\hline			
+\end{longtable}

--- a/9control.tex
+++ b/9control.tex
@@ -2595,31 +2595,19 @@ Depending upon the entered options above subsequent conditional inputs may be ne
 		\end{itemize}
 \end{itemize}
 
-
-		
-\begin{longtable}{p{1.1cm} p{1.4cm} p{1.2cm} p{1.2cm} p{1.3cm} p{1.6cm} p{1.4cm} p{1.4cm} p{1.4cm}}
-	
-	\hline
-	\multicolumn{9}{l}{Example Input:}\Tstrut\Bstrut\\
-	\hline
-	
-	\multicolumn{3}{l}{1} & \multicolumn{6}{l}{0 = No additional std dev reporting;} \Tstrut\\
-	\multicolumn{3}{l}{ } & \multicolumn{6}{l}{1 = read values below; and}\Bstrut\\
-	\multicolumn{3}{l}{ } & \multicolumn{6}{l}{2 = read specification for reporting stdev for selectivity, size,numbers, and }\Bstrut\\
-	\multicolumn{3}{l}{ } & \multicolumn{6}{l}{natural mortality.}\Bstrut\\
-	\hline
-	
-	\multicolumn{4}{l}{ 1 1 -1 5} & \multicolumn{5}{l}{\# Selectivity} \Bstrut\\
-	\multicolumn{4}{l}{ 1 5}      & \multicolumn{5}{l}{\# Growth} \Bstrut\\
-	\multicolumn{4}{l}{1 -1 5}    & \multicolumn{5}{l}{\# Numbers-at-age} \Bstrut\\
-
-	\multicolumn{4}{l}{5 15 25 35 43} & \multicolumn{5}{l}{\# Vector with selectivity std bins (-1 in first bin to self-generate)}\Bstrut\\
-	\multicolumn{4}{l}{1 2 14 26 40}  & \multicolumn{5}{l}{\# Vector with growth std ages picks (-1 in first bin to self-generate)}\Bstrut\\
-	\multicolumn{4}{l}{1 2 14 26 40}  & \multicolumn{5}{l}{\# Vector with numbers-at-age std ages (-1 in first bin to self-generate)}\Bstrut\\
-	
-	\hline
-	\bfseries{999} & \multicolumn{8}{l}{\#End of the control file input}\Tstrut\Bstrut\\
-	\hline			
-\end{longtable}
+Example input:	
+<pre><code>
+2 # (0/1/2) read specs for more stddev reporting: 0 = skip, 1 = read specs for reporting stdev for selectivity, size, and numbers, 2 = add options for M,Dyn. Bzero, SmryBio
+ 1 1 -1 5 # Selectivity: (1) 0 to skip or fleet, (2) 1=len/2=age/3=combined, (3) year, (4) N selex bins; NOTE: combined reports in age bins
+ 1 5 # Growth: (1) 0 to skip or growth pattern, (2) growth ages; NOTE: does each sex
+ 1 -1 5 # Numbers-at-age: (1) 0 or area(-1 for all), (2) year, (3) N ages;  NOTE: sums across morphs
+ 1 5 # Mortality: (1) 0 to skip or growth pattern, (2) N ages for mortality; NOTE: does each sex
+1 # Dyn Bzero: 0 to skip, 1 to include, or 2 to add recr
+1 # SmryBio: 0 to skip, 1 to include
+ 5 15 25 35 38 # vector with selex std bins (-1 in first bin to self-generate)
+ 1 2 5 10 15 # vector with growth std ages picks (-1 in first bin to self-generate)
+ 1 2 5 10 15 # vector with NatAge std ages (-1 in first bin to self-generate)
+ 1 2 5 10 15 # vector with NatM std ages picks (-1 in first bin to self-generate)
+</code></pre>
 
 to end year + 1, hence the year that starts the forecast period.

--- a/9control.tex
+++ b/9control.tex
@@ -2541,7 +2541,7 @@ COND = 1 or 2: Read the following lines (split into 3 rows for readability):
 	\begin{enumerate}
 		\item fleet number (or 0 if not used),
 		\item type of selectivity to report: 1 = length, 2 = age, or 3 = combined (age with length),
-		\item year, and
+		\item year (enter -1 for end year), and
 		\item number of bins to report, list entered below (note - combined will report in age bins).
 	\end{enumerate}	
 	\item 2 values related to growth:
@@ -2552,7 +2552,7 @@ COND = 1 or 2: Read the following lines (split into 3 rows for readability):
 	\item 3 values related to numbers-at-age:
 	\begin{enumerate}
 		\item area (enter -1 for sum of all areas), or 0 for not used,
-		\item year, and
+		\item year (enter -1 for end year + 1), and
 		\item number of ages to report, list entered below (note - each sex will be reported and summed across growth patterns).
 	\end{enumerate}
 \end{itemize}
@@ -2596,7 +2596,8 @@ Depending upon the entered options above subsequent conditional inputs may be ne
 \end{itemize}
 
 Example input:	
-<pre><code>
+\begin{quote}
+	\begin{verbatim}
 2 # (0/1/2) read specs for more stddev reporting: 0 = skip, 1 = read specs for reporting stdev for selectivity, size, and numbers, 2 = add options for M,Dyn. Bzero, SmryBio
  1 1 -1 5 # Selectivity: (1) 0 to skip or fleet, (2) 1=len/2=age/3=combined, (3) year, (4) N selex bins; NOTE: combined reports in age bins
  1 5 # Growth: (1) 0 to skip or growth pattern, (2) growth ages; NOTE: does each sex
@@ -2608,6 +2609,6 @@ Example input:
  1 2 5 10 15 # vector with growth std ages picks (-1 in first bin to self-generate)
  1 2 5 10 15 # vector with NatAge std ages (-1 in first bin to self-generate)
  1 2 5 10 15 # vector with NatM std ages picks (-1 in first bin to self-generate)
-</code></pre>
+\end{verbatim}
+\end{quote}
 
-to end year + 1, hence the year that starts the forecast period.

--- a/9control.tex
+++ b/9control.tex
@@ -2598,22 +2598,22 @@ Depending upon the entered options above subsequent conditional inputs may be ne
 Example input:	
 \begin{quote}
 	\begin{verbatim}
-2 # (0/1/2) read specs for more stddev reporting: 
-  # 0 = skip, 1 = read specs for reporting stdev for selectivity, size, 
-  # and numbers, 2 = add options for M,Dyn. Bzero, SmryBio
- 1 1 -1 5 # Selectivity: (1) 0 to skip or fleet, (2) 1=len/2=age/3=combined, 
-          # (3) year, (4) N selex bins; NOTE: combined reports in age bins
- 1 5 # Growth: (1) 0 to skip or growth pattern, (2) growth ages; 
-     # NOTE: does each sex
- 1 -1 5 # Numbers-at-age: (1) 0 or area(-1 for all), (2) year, (3) N ages;  
-        # NOTE: sums across morphs
- 1 5 # Mortality: (1) 0 to skip or growth pattern, (2) N ages for mortality; 
-     # NOTE: does each sex
-1 # Dyn Bzero: 0 to skip, 1 to include, or 2 to add recr
-1 # SmryBio: 0 to skip, 1 to include
- 5 15 25 35 38 # vector with selex std bins (-1 in first bin to self-generate)
- 1 2 5 10 15 # vector with growth std ages picks (-1 in first bin to self-generate)
- 1 2 5 10 15 # vector with NatAge std ages (-1 in first bin to self-generate)
- 1 2 5 10 15 # vector with NatM std ages picks (-1 in first bin to self-generate)
+2 \# \(0/1/2\) read specs for more stddev reporting: 
+  \# 0 = skip, 1 = read specs for reporting stdev for selectivity, size, 
+  \# and numbers, 2 = add options for M,Dyn. Bzero, SmryBio
+ 1 1 -1 5 \# Selectivity: \(1\) 0 to skip or fleet, \(2\) 1=len/2=age/3=combined, 
+          \# \(3\) year, \(4\) N selex bins; NOTE: combined reports in age bins
+ 1 5 \# Growth: \(1\) 0 to skip or growth pattern, \(2\) growth ages; 
+     \# NOTE: does each sex
+ 1 -1 5 \# Numbers-at-age: \(1\) 0 or area\(-1 for all\), \(2\) year, \(3\) N ages;  
+        \# NOTE: sums across morphs
+ 1 5 \# Mortality: \(1\) 0 to skip or growth pattern, \(2\) N ages for mortality; 
+     \# NOTE: does each sex
+1 \# Dyn Bzero: 0 to skip, 1 to include, or 2 to add recr
+1 \# SmryBio: 0 to skip, 1 to include
+ 5 15 25 35 38 \# vector with selex std bins \(-1 in first bin to self-generate\)
+ 1 2 5 10 15 \# vector with growth std ages picks \(-1 in first bin to self-generate\)
+ 1 2 5 10 15 \# vector with NatAge std ages \(-1 in first bin to self-generate\)
+ 1 2 5 10 15 \# vector with NatM std ages picks \(-1 in first bin to self-generate\)
 \end{verbatim}
 \end{quote}


### PR DESCRIPTION
This PR expands the example for "Controls for Variance of Derived Quantities" to use option 2 which includes more variables. This is based on a setup that I just used successfully for Petrale Sole.

It also fixes a few minor issues with the previous description. A screenshot of the example input looks in HTML in below (the PDF looks fine too).

It took 5 commits to make this simple change because I was trying and failing to shortcut to using \begin{quote}\begin{verbatim} instead, so we should squash the commits when merging to clean things up.

![image](https://user-images.githubusercontent.com/4992918/211432058-dcabc504-ab04-4337-ac66-557c8f26f501.png)

