### PR TITLE
change font in html from Georgia to Arial

### DIFF
--- a/.github/workflows/call-deploy-ss3-docs.yml
+++ b/.github/workflows/call-deploy-ss3-docs.yml
@@ -9,4 +9,4 @@ on:
   workflow_dispatch:
 jobs:
   call-workflow:
-    uses: nmfs-stock-synthesis/workflows/.github/workflows/deploy-ss3-docs.yml@main
+    uses: nmfs-stock-synthesis/workflows/.github/workflows/deploy-ss3-docs.yml@change-html-font

--- a/.github/workflows/call-deploy-ss3-docs.yml
+++ b/.github/workflows/call-deploy-ss3-docs.yml
@@ -1,7 +1,7 @@
 name: Build documentation and deploy it to the website
 on:
   push:
-    branches: main
+    branches: change-html-font
     paths:
       - '**.tex'
       - '**.Rmd'

--- a/.github/workflows/call-deploy-ss3-docs.yml
+++ b/.github/workflows/call-deploy-ss3-docs.yml
@@ -1,7 +1,7 @@
 name: Build documentation and deploy it to the website
 on:
   push:
-    branches: change-html-font
+    branches: main
     paths:
       - '**.tex'
       - '**.Rmd'
@@ -9,4 +9,4 @@ on:
   workflow_dispatch:
 jobs:
   call-workflow:
-    uses: nmfs-stock-synthesis/workflows/.github/workflows/deploy-ss3-docs.yml@change-html-font
+    uses: nmfs-stock-synthesis/workflows/.github/workflows/deploy-ss3-docs.yml@main

--- a/docs/html_usermanual.css
+++ b/docs/html_usermanual.css
@@ -23,7 +23,7 @@
 	}
     html {
       line-height: 1.5;
-      font-family: Georgia, serif;
+      font-family: Arial, sans-serif;
       font-size: 20px;
       color: #1a1a1a;
       background-color: #fdfdfd;


### PR DESCRIPTION
Font changed in the html css file in the docs folder to be Arial, a sans-serif font as opposed to Georgia, a serif font. @kellijohnson-NOAA pointed out that there was a weird size difference in the numbers which turned out to just be a feature of the Georgia font, changing it to a font that doesn't have that size difference as a feature will get rid of that.