### PR TITLE
Fix minor typos

### DIFF
--- a/.github/workflows/build-ss3-manual-html.yml
+++ b/.github/workflows/build-ss3-manual-html.yml
@@ -54,7 +54,7 @@ jobs:
           # remove inline style
           style_sec <- grep("style>", html_txt)
           html_txt <- html_txt[-(style_sec[1]:style_sec[2])]
-          # add in the the navbar
+          # add in the navbar
           navbar_snip <- grep("div", html_snips)
           navbar_snip <- html_snips[navbar_snip[1]:navbar_snip[2]]
           html_txt <- append(html_txt, navbar_snip, after = grep("<html", html_txt))

--- a/1_4sections.tex
+++ b/1_4sections.tex
@@ -44,7 +44,7 @@ Methot, R. D., Jr., C. R. Wetzel, I. G. Taylor, and K. Doering. (2020). Stock Sy
 	
 	\subsection{Output Files}
 	\begin{enumerate}
-		\item data\_echo.ss\_new: Contains the input data as read by the model. In model versions prior to 3.30.19 a single data.ss\_new file was created that included the echoed data, the expected data values (data\_expval.ss), and any bootstap data files selected (data\_boot\_x.ss).
+		\item data\_echo.ss\_new: Contains the input data as read by the model. In model versions prior to 3.30.19 a single data.ss\_new file was created that included the echoed data, the expected data values (data\_expval.ss), and any bootstrap data files selected (data\_boot\_x.ss).
 		\item data\_expval.ss: Contains the expected data values given the model fit. This file is only created if the value for ``Number of datafiles to produce'' in the starter file is set to 2 or greater.
 		\item data\_boot\_x.ss: A new data file filled with bootstrap data based on the original input data and variances. This file is only created if the value in the ``Number of datafiles to produc'' in the starter file is set to 3 or greater. A separate bootstrap data file will be written for the number of bootstrap data file requests where x in the file name indicates the bootstrap simulation number (e.g., data\_boot\_001.ss, data\_boot\_002.ss,...).
 		\item control.ss\_ new: Updated version of the control file with final parameter values replacing the initial parameter values.

--- a/9control.tex
+++ b/9control.tex
@@ -774,7 +774,7 @@ Note that predator calculations probably will fail if tried with F Method=1 (Pop
 
 	& Lmin & Length at Amin (units in cm) for female, growth pattern 1. \\
 	& Lmax & Length at Amax (units in cm) for female, growth pattern 1. \\
-	& VBK & von Bertanlaffy growth coefficient (units are per year) for females, growth pattern 1. \Bstrut\\
+	& VBK & von Bertalanffy growth coefficient (units are per year) for females, growth pattern 1. \Bstrut\\
 	\hline
 
 	\multicolumn{2}{l}{COND if growth type = 2 } & \Tstrut\\
@@ -808,7 +808,7 @@ Note that predator calculations probably will fail if tried with F Method=1 (Pop
 		
 	& Lmin & Length at Amin (units in cm) for male, growth pattern 1. In a two sex model, fixing the INIT value a 0 will assume the same Lmin as the female parameter value. \\
 	& Lmax & Length at Amax (units in cm) for male, growth pattern 1. In a two sex model, fixing the INIT value a 0 will assume the same Lmax as the female parameter value. \\
-	& VBK & von Bertanlaffy growth coefficient (units are per year) for males, growth pattern 1. In a two sex model, fixing the INIT value a 0 will assume the same k as the female parameter value. \Bstrut\\
+	& VBK & von Bertalanffy growth coefficient (units are per year) for males, growth pattern 1. In a two sex model, fixing the INIT value a 0 will assume the same k as the female parameter value. \Bstrut\\
 	\hline
 
 	\multicolumn{2}{l}{COND if growth type = 2} & \Tstrut\\

--- a/SS.bib
+++ b/SS.bib
@@ -114,6 +114,7 @@
 
 @article{punt_insights_2016,
 	title = {Some insights into data weighting in integrated stock assessments},
+	volume = {192},
 	issn = {01657836},
 	url = {http://linkinghub.elsevier.com/retrieve/pii/S0165783615301582},
 	doi = {10.1016/j.fishres.2015.12.006},
@@ -123,6 +124,7 @@
 	author = {Punt, André E.},
 	month = jan,
 	year = {2016},
+	pages = {52--65},
 	file = {Punt - 2016 - Some insights into data weighting in integrated st.pdf:C\:\\Users\\Chantel.Wetzel\\Zotero\\storage\\Q4HVWB5J\\Punt - 2016 - Some insights into data weighting in integrated st.pdf:application/pdf},
 }
 

--- a/SS.bib
+++ b/SS.bib
@@ -380,7 +380,7 @@
 @article{schnute1981growth,
   title={A versatile growth model with statistically stable parameters},
   author={Schnute, Jon},
-  journal={Canadian Joural of Fisheries and Aquatic Science},
+  journal={Canadian Journal of Fisheries and Aquatic Science},
   volume={38},
   pages={1128--1140},
   year={1981}

--- a/User_Guides/model_step_by_step/model_tutorial.Rmd
+++ b/User_Guides/model_step_by_step/model_tutorial.Rmd
@@ -342,7 +342,7 @@ Then, the setup lines for maturity, fecundity, and other specialized options:
 0 #_hermaphroditism option:  0=none; 1=female-to-male age-specific fxn; -1=male-to-female age-specific fxn
 1 #_parameter_offset_approach (1=none, 2= M, G, CV_G as offset from female-GP1, 3=like SS2 V1.x)
 ```
-The parameter lines resulting from the natural mortality, growth, and maturity (this section is sometimes called MG parms) are specified next. The number of paramter lines depends on the options selected in the setup lines. The parameters must also be specified in a particular order, with female parameters coming before male parameters in a 2-sex model:
+The parameter lines resulting from the natural mortality, growth, and maturity (this section is sometimes called MG parms) are specified next. The number of parameter lines depends on the options selected in the setup lines. The parameters must also be specified in a particular order, with female parameters coming before male parameters in a 2-sex model:
 ```{r eval = FALSE}
 #_ LO HI INIT PRIOR PR_SD PR_type PHASE env_var&link dev_link dev_minyr dev_maxyr dev_PH Block Block_Fxn
 # Sex: 1  BioPattern: 1  NatMort
@@ -521,7 +521,7 @@ A selectivity pattern must be specified for both size and age selectivity for ea
 #_no timevary selex parameters
 #
 ```
-These paramter lines are specified in order, with the size (or length) selectivity lines specified before the age selectivity lines and the fleets in the same order as in the setup lines. Also, the selectivity pattern used determines the number of parameters needed to specify each fleets' size or age selectivity.
+These parameter lines are specified in order, with the size (or length) selectivity lines specified before the age selectivity lines and the fleets in the same order as in the setup lines. Also, the selectivity pattern used determines the number of parameters needed to specify each fleets' size or age selectivity.
 
 Some special features (2DAR selectivity, tagging data, variance adjusment, lambdas, and additional standard deviation reporting) in the control file are turned off for this model:
 ```{r eval = FALSE}

--- a/User_Guides/model_step_by_step/model_tutorial.Rmd
+++ b/User_Guides/model_step_by_step/model_tutorial.Rmd
@@ -406,7 +406,7 @@ Next, the Spawner recruitment setup and Spawner recruit long parameter lines are
 0  # 0/1 to use steepness in initial equ recruitment calculation
 0  #  future feature:  0/1 to make realized sigmaR a function of SR curvature
 ```
-which effects the number of SR parameter lines that follow:
+which affects the number of SR parameter lines that follow:
 ```{r eval = FALSE}
 #_          LO            HI          INIT         PRIOR         PR_SD       PR_type      PHASE    env-var    use_dev   dev_mnyr   dev_mxyr     dev_PH      Block    Blk_Fxn #  parm_name
              3            31       8.81505          10.3            10             0          1          0          0          0          0          0          0          0 # SR_LN(R0)

--- a/User_Guides/model_step_by_step/model_tutorial.Rmd
+++ b/User_Guides/model_step_by_step/model_tutorial.Rmd
@@ -35,7 +35,7 @@ No aging error bias is assumed and aging is considered to be very precise.
 
 ### Natural mortality, growth, maturity, and sex ratio
 
-All parameters are assumed to be the same over time. Natural mortality is specified at 0.1. A von Bertalanfy growth curve is used with K estimated. Maturity is assumed to be length logistic with some specified parameter values. The sex ratio is assumed 50-50 female and male.
+All parameters are assumed to be the same over time. Natural mortality is specified at 0.1. A von Bertalanffy growth curve is used with K estimated. Maturity is assumed to be length logistic with some specified parameter values. The sex ratio is assumed 50-50 female and male.
 
 ### Spawner-Recruitment
 

--- a/User_Guides/model_step_by_step/model_tutorial.Rmd
+++ b/User_Guides/model_step_by_step/model_tutorial.Rmd
@@ -144,7 +144,7 @@ Next comes specification for indices of abundance. First is the setup for all of
 3 0 0 0 # SURVEY2
 
 ```
-The column headers for this section are directly above the numbers. Note that all fleets are defined here (i.e., each fleet needs a line), including the fishery and are listed in the same order as when the fleet types were specified. Most importantly in this section, the units and error type that will be used when reading the the indices of abundance are specified. In this case, the fishery and survey 1 have units of biomass, wheras survey 2 is in numbers. Lognormal error is assumed for all 3 of the fleets.
+The column headers for this section are directly above the numbers. Note that all fleets are defined here (i.e., each fleet needs a line), including the fishery and are listed in the same order as when the fleet types were specified. Most importantly in this section, the units and error type that will be used when reading the indices of abundance are specified. In this case, the fishery and survey 1 have units of biomass, wheras survey 2 is in numbers. Lognormal error is assumed for all 3 of the fleets.
 
 Directly after its header, the indices of abundance data is included: 
 

--- a/User_Guides/ss_model_tips/ss_model_tips.Rmd
+++ b/User_Guides/ss_model_tips/ss_model_tips.Rmd
@@ -154,7 +154,7 @@ The `r4ss::SS_output()` function prints information on tuning to the R console. 
 
 ## Did I fix variation in recruitment correctly?
 
-Check the the sigmaR (i.e., recruitment devs standard deviation) information. The sigmaR parameter is typically fixed within the model, so if it is not fixed within your model, you should consider whether or not this makes sense for the population and given the quality and quantity of data.
+Check the sigmaR (i.e., recruitment devs standard deviation) information. The sigmaR parameter is typically fixed within the model, so if it is not fixed within your model, you should consider whether or not this makes sense for the population and given the quality and quantity of data.
 
 For a fixed value of sigmaR, a section of the output will provide diagnostics to determine if the fixed sigmaR value is capturing the estimated variations in recruitment. The `r4ss::SS_output()` function will print a recommended value based on the variation in the estimated recruitment deviations that you may want to consider using.
 

--- a/technical_description/13biology.Rmd
+++ b/technical_description/13biology.Rmd
@@ -59,7 +59,7 @@ Equation \ref{eqn8} would logically use natural mortality as the decay factor. H
 
 ## Growth
 
-The mean size-at-age for the von Bertanlaffy growth curve by sex at the start of each season for each growth morph is incremented across years as:
+The mean size-at-age for the von Bertalanffy growth curve by sex at the start of each season for each growth morph is incremented across years as:
 
 \begin{equation}
 \label{eqn9}

--- a/technical_description/_main.knit.md
+++ b/technical_description/_main.knit.md
@@ -216,7 +216,7 @@ Equation \ref{eqn8} would logically use natural mortality as the decay factor. H
 
 ## Growth
 
-The mean size-at-age for the von Bertanlaffy growth curve by sex at the start of each season for each growth morph is incremented across years as:
+The mean size-at-age for the von Bertalanffy growth curve by sex at the start of each season for each growth morph is incremented across years as:
 
 \begin{equation}
 \label{eqn9}

--- a/technical_description/_main.md
+++ b/technical_description/_main.md
@@ -216,7 +216,7 @@ Equation \ref{eqn8} would logically use natural mortality as the decay factor. H
 
 ## Growth
 
-The mean size-at-age for the von Bertanlaffy growth curve by sex at the start of each season for each growth morph is incremented across years as:
+The mean size-at-age for the von Bertalanffy growth curve by sex at the start of each season for each growth morph is incremented across years as:
 
 \begin{equation}
 \label{eqn9}

--- a/technical_description/_main.tex
+++ b/technical_description/_main.tex
@@ -493,7 +493,7 @@ Equation \ref{eqn8} would logically use natural mortality as the decay factor. H
 
 \tagstructbegin{tag=P}\tagmcbegin{tag=P}
 
-The mean size-at-age for the von Bertanlaffy growth curve by sex at the start of each season for each growth morph is incremented across years as:
+The mean size-at-age for the von Bertalanffy growth curve by sex at the start of each season for each growth morph is incremented across years as:
 
 \leavevmode\tagmcend\tagstructend\par
 


### PR DESCRIPTION
Hi! This pull request fixes minor typos:

- bootstap -> bootstrap
- the the -> the
- effects -> affects
- paramter -> parameter
- von Bert*y -> von Bertalanffy
- Joural -> Journal
- Volume and pages for Punt (2016) bib entry

All harmless, just cosmetic improvements.