### PR TITLE
add note about retention required for part = 2

### DIFF
--- a/8data.tex
+++ b/8data.tex
@@ -561,10 +561,11 @@ This is the overall mean body weight or length across all selected sizes and age
 
 \myparagraph{Partition}
 Mean weight data and composition data require specification of what group the sample originated from (e.g., discard, retained, discard + retained).
+Note: if retention is not defined in the selectivity section, observations with Partition = 2 will be changed to Partition = 0.
 \begin{itemize}
-	\item 0 = whole catch in units of weight (discard + retained);
+	\item 0 = combined catch in units of weight (discard + retained);
 	\item 1 = discarded catch in units of weight; and
-	\item 2 = retained catch in units of weight. (Note: if retention is not defined in the selectivity section, observations with Part = 2 will be change to Part = 0)
+	\item 2 = retained catch in units of weight.
 \end{itemize}
 
 \myparagraph{Type}	
@@ -774,9 +775,10 @@ In a 2 sex model, the data vector always has female data followed by male data, 
 	\end{itemize}
 
 \myparagraph{Partition}
-Partition indicates samples from either discards,retained, or combined.
+Partition indicates samples from either combined, discards, or retained catch. 
+Note: if retention is not defined in the selectivity section, observations with Partition = 2 will be changed to Partition = 0.
 	\begin{itemize}
-		\item 0 = combined;
+		\item 0 = combined (discard + retained);
 		\item 1 = discard; and
 		\item 2 = retained.
 	\end{itemize}

--- a/8data.tex
+++ b/8data.tex
@@ -564,7 +564,7 @@ Mean weight data and composition data require specification of what group the sa
 \begin{itemize}
 	\item 0 = whole catch in units of weight (discard + retained);
 	\item 1 = discarded catch in units of weight; and
-	\item 2 = retained catch in units of weight.
+	\item 2 = retained catch in units of weight. (Note: if retention is not defined in the selectivity section, observations with Part = 2 will be change to Part = 0)
 \end{itemize}
 
 \myparagraph{Type}	

--- a/8data.tex
+++ b/8data.tex
@@ -563,7 +563,7 @@ This is the overall mean body weight or length across all selected sizes and age
 Mean weight data and composition data require specification of what group the sample originated from (e.g., discard, retained, discard + retained).
 Note: if retention is not defined in the selectivity section, observations with Partition = 2 will be changed to Partition = 0.
 \begin{itemize}
-	\item 0 = combined catch in units of weight (discard + retained);
+	\item 0 = combined catch in units of weight (whole, e.g. discard + retained);
 	\item 1 = discarded catch in units of weight; and
 	\item 2 = retained catch in units of weight.
 \end{itemize}
@@ -778,7 +778,7 @@ In a 2 sex model, the data vector always has female data followed by male data, 
 Partition indicates samples from either combined, discards, or retained catch. 
 Note: if retention is not defined in the selectivity section, observations with Partition = 2 will be changed to Partition = 0.
 	\begin{itemize}
-		\item 0 = combined (discard + retained);
+		\item 0 = combined (whole, e.g. discard + retained);
 		\item 1 = discard; and
 		\item 2 = retained.
 	\end{itemize}
@@ -1021,7 +1021,7 @@ The generalized approach to size composition information was designed initially 
 	\item Each method has ``units'' so the frequencies can be in units of biomass or numbers.
 	\item Each method has ``scale'' so the bins can be in terms of weight or length (including ability to convert bin definitions in pounds or inches to kg or cm). 
 	\item The composition data is input as females then males, just like all other composition data in SS3. In a two-sex model, the new composition data can be combined sex, single sex, or both sex.
-	\item The generalized size composition data can be from the combined discard and retained, discard only, or retained only.
+	\item The generalized size composition data can be from the combined discard and retained (i.e., whole), discard only, or retained only.
 	\item There are two options for treating fish that in population size bins are smaller than the smallest size frequency bin.
 	\begin{itemize}
 		\item Option 1: By default, these fish are excluded (unlike length composition data where the small fish are automatically accumulated up into the first bin.)


### PR DESCRIPTION
This change adds a note "Note: if retention is not defined in the selectivity section, observations with Partition = 2 will be changed to Partition = 0" to the two descriptions of partition (in the "Mean Body Weight or Length" and "Length Composition Data" sections) and also aligns the descriptions with each other a little bit.

Resolves #153.